### PR TITLE
Increase limbo duration for disconnected players

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -60,7 +60,7 @@ impl ArenaService for Server {
     const TICK_PERIOD_SECS: f32 = Ticks::PERIOD_SECS;
 
     /// How long a player can remain in limbo after they lose connection.
-    const LIMBO: Duration = Duration::from_secs(6);
+    const LIMBO: Duration = Duration::from_secs(30); // maybe 60 if doesn't put heavy load on the servers!
 
     type Bot = Bot;
     type ClientData = ClientData;


### PR DESCRIPTION
## Summary

Increase the server-side LIMBO duration (player grace period for reconnecting after disconnect) from 6 seconds to 30 seconds. This change helps players impacted by short/unstable network interruptions to resume their session without losing progress.

Feel free to make it 60 instead of 30 if possible as other games have it too and some of other games of softbear like kiomet.

## Details

- **Old value:**  
  ```rust
  const LIMBO: Duration = Duration::from_secs(6);
  ```

- **New value:**  
  ```rust
  /// How long a player can remain in limbo ("disconnected" state) after losing connection.
  /// If they reconnect within this period, their progress is preserved.
  /// Increased to be more forgiving to players with unstable networks.
  const LIMBO: Duration = Duration::from_secs(30); // 30 seconds grace period
  ```

- The change is located in `server/src/server.rs` inside the `impl ArenaService for Server` block.

## Rationale

- **Player Experience:** Short network disruptions often cause players’ progress to be lost when LIMBO is too low.
- **Industry Norms:** Many multiplayer games use a 30-120 second reconnection grace period.
- **Server Impact:** Limited; only in-memory session state is preserved a little longer per disconnect.

## Potential Future Improvements

- Make LIMBO duration configurable (e.g. via config file or environment variable).
- Track metrics on reconnection/save rate to further optimize player experience.

---

**Fixes / improves # [related issue/feedback]**